### PR TITLE
Drop pinecard version

### DIFF
--- a/src/pinefarm/external/interface.py
+++ b/src/pinefarm/external/interface.py
@@ -111,14 +111,7 @@ class External(abc.ABC):
         # the pinefarm version will also pin pineappl_py version and all the
         # other python dependencies versions
         versions["pinefarm"] = __version__
-        versions["pinecard"] = pygit2.Repository(
-            configs.configs["paths"]["root"]
-        ).describe(
-            always_use_long_format=True,
-            describe_strategy=pygit2.GIT_DESCRIBE_TAGS,
-            dirty_suffix="-dirty",
-            show_commit_oid_as_fallback=True,
-        )
+        # TODO add pinecard - see https://github.com/NNPDF/pinefarm/issues/15
         # TODO: add pineappl version
         #  pineappl = configs.configs["commands"]["pineappl"]()
         versions["pineappl_capi"] = "???"


### PR DESCRIPTION
related to https://github.com/NNPDF/runcards/pull/159

since the original behaviour resulted into a failure I suggest to drop the pinecard for the moment completely and then do the proper job in https://github.com/NNPDF/pinefarm/issues/15