### PR TITLE
Make `shutil.move` py38 compatible

### DIFF
--- a/src/pinefarm/cli/merge.py
+++ b/src/pinefarm/cli/merge.py
@@ -70,7 +70,7 @@ def main(grids):
     tools.update_grid_metadata(
         mgrid_path, mgridtmp, entries={"results": "\n".join(tmpresults)}
     )
-    shutil.move(str(mgridtmp), mgrid_path)
+    shutil.move(str(mgridtmp), str(mgrid_path))
 
     mkeys = mgrid.key_values()
     for key in keys:

--- a/src/pinefarm/cli/update.py
+++ b/src/pinefarm/cli/update.py
@@ -36,6 +36,6 @@ def main(datasets):
         tools.update_grid_metadata(path, dest, entries)
         compressed = tools.compress(dest)
         dest.unlink()
-        shutil.move(compressed, path)
+        shutil.move(str(compressed), str(path))
 
         rich.print(f"'{path}'\n\tgrid metadata updated")

--- a/src/pinefarm/external/interface.py
+++ b/src/pinefarm/external/interface.py
@@ -57,7 +57,7 @@ class External(abc.ABC):
 
     def update_with_tmp(self):
         """Move intermediate grid to final position."""
-        shutil.move(self.gridtmp, self.grid)
+        shutil.move(str(self.gridtmp), str(self.grid))
 
     @staticmethod
     def install():

--- a/src/pinefarm/install.py
+++ b/src/pinefarm/install.py
@@ -72,7 +72,7 @@ def mg5amc():
     if len(content) == 1:
         # in case, remove the intermediate layer
         for el in content[0].iterdir():
-            shutil.move(el, dest)
+            shutil.move(str(el), str(dest))
         content[0].rmdir()
 
     # in case we're using python3, we need to convert the model file


### PR DESCRIPTION
Closes #18 

https://docs.python.org/3/library/shutil.html?highlight=shutil#shutil.move

> Changed in version 3.9: Accepts a [path-like object](https://docs.python.org/3/glossary.html#term-path-like-object) for both src and dst.