### PR TITLE
update pinecards path

### DIFF
--- a/src/pinefarm/external/interface.py
+++ b/src/pinefarm/external/interface.py
@@ -112,7 +112,7 @@ class External(abc.ABC):
         # other python dependencies versions
         versions["pinefarm"] = __version__
         versions["pinecard"] = pygit2.Repository(
-            configs.configs["paths"]["root"]
+            configs.configs["paths"]["runcards"]
         ).describe(
             always_use_long_format=True,
             describe_strategy=pygit2.GIT_DESCRIBE_TAGS,


### PR DESCRIPTION
Before pinefarm was moved out of the pinecards repo, the runcards were in the 'root' directory. Now that is no longer the case. I think that explains the need for this update.