### PR TITLE
Skip `lhapdf_conf` if environment is set

### DIFF
--- a/src/pinefarm/install.py
+++ b/src/pinefarm/install.py
@@ -258,6 +258,9 @@ def lhapdf_conf(pdf):
         LHAPDF name of the required PDF
 
     """
+    # user settings *always* take precedence
+    if os.environ["LHAPDF_DATA_PATH"]:
+        return
     if shutil.which("lhapdf-config") is not None or pkgconfig.exists("lhapdf"):
         lhapdf_data = pathlib.Path(
             subprocess.run("lhapdf-config --datadir".split(), capture_output=True)

--- a/src/pinefarm/install.py
+++ b/src/pinefarm/install.py
@@ -259,7 +259,7 @@ def lhapdf_conf(pdf):
 
     """
     # user settings *always* take precedence
-    if os.environ["LHAPDF_DATA_PATH"]:
+    if os.environ.get("LHAPDF_DATA_PATH") is not None:
         return
     if shutil.which("lhapdf-config") is not None or pkgconfig.exists("lhapdf"):
         lhapdf_data = pathlib.Path(


### PR DESCRIPTION
All the mess in `lhapdf_conf` really looks suspicious ... but I guess there was a reason upon time ...