### PR TITLE
Fix polarized integrability

### DIFF
--- a/src/pinefarm/external/integrability.py
+++ b/src/pinefarm/external/integrability.py
@@ -101,7 +101,12 @@ class Integrability(interface.External):
         q2 = self._q2 * np.ones_like(self._info.xgrid)
 
         for fl, w in self._evo2fl:
-            final_result += w * np.sum(pdf.xfxQ2(fl, self._info.xgrid, q2))
+            norm = 1.0
+            # in the polarized case we want to integrate the first moment
+            if self.polarized:
+                norm = 1 / self._info.xgrid
+            final_result += norm * w * np.sum(pdf.fxQ2(fl, self._info.xgrid, q2))
+    
         final_cv = [final_result]
 
         d = {

--- a/src/pinefarm/external/integrability.py
+++ b/src/pinefarm/external/integrability.py
@@ -43,6 +43,7 @@ class _IntegrabilityRuncard:
     lepton_pid: int
     flavour: int
     xgrid: typing.List[float]
+    polarized: typing.Optional[str] = "False"
 
     def asdict(self):
         return dataclasses.asdict(self)
@@ -59,7 +60,7 @@ class Integrability(interface.External):
         self._q2 = np.power(self.theory["Q0"], 2)
         self._info = _IntegrabilityRuncard(**yaml_dict)
         self._evo2fl = evolution_to_flavour(self._info.flavour)
-        self.polarized = yaml_dict.get("polarized", "False")
+        self.polarized = self._info.polarized
 
     def run(self):
         """Empty function."""
@@ -107,8 +108,8 @@ class Integrability(interface.External):
             norm = 1.0
             # in the polarized case we want to integrate the first moment
             if self.polarized:
-                norm = 1 / self._info.xgrid
-            final_result += norm * w * np.sum(pdf.fxQ2(fl, self._info.xgrid, q2))
+                norm = 1 / float(self._info.xgrid[0])
+            final_result += norm * w * np.sum(pdf.xfxQ2(fl, self._info.xgrid, q2))
 
         final_cv = [final_result]
 

--- a/src/pinefarm/external/integrability.py
+++ b/src/pinefarm/external/integrability.py
@@ -80,10 +80,13 @@ class Integrability(interface.External):
         grid.set_key_value("runcard", json.dumps(self._info.asdict()))
         grid.set_key_value("lumi_id_types", "pdg_mc_ids")
         grid.set_key_value("polarized", self.polarized)
-        # Fill grid with x*Tn
+        # Fill grid with x*f(x) or f(x)
         # use subgrid because fill doesn't work?
         x = self._info.xgrid
-        w = np.array(x).reshape((1, -1, 1))
+        if self.polarized:
+            w = np.array(1.0).reshape((1, -1, 1))
+        else:
+            w = np.array(x).reshape((1, -1, 1))
         sg = pineappl.import_only_subgrid.ImportOnlySubgridV1(w, [self._q2], x, x)
         grid.set_subgrid(0, 0, 0, sg)
         grid.write(self.grid)

--- a/src/pinefarm/external/integrability.py
+++ b/src/pinefarm/external/integrability.py
@@ -109,7 +109,7 @@ class Integrability(interface.External):
             if self.polarized:
                 norm = 1 / self._info.xgrid
             final_result += norm * w * np.sum(pdf.fxQ2(fl, self._info.xgrid, q2))
-    
+
         final_cv = [final_result]
 
         d = {

--- a/src/pinefarm/external/integrability.py
+++ b/src/pinefarm/external/integrability.py
@@ -81,13 +81,10 @@ class Integrability(interface.External):
         grid.set_key_value("runcard", json.dumps(self._info.asdict()))
         grid.set_key_value("lumi_id_types", "pdg_mc_ids")
         grid.set_key_value("polarized", self.polarized)
-        # Fill grid with x*f(x) or f(x)
+        # Fill grid with x*f(x)
         # use subgrid because fill doesn't work?
         x = self._info.xgrid
-        if self.polarized:
-            w = np.array(1.0).reshape((1, -1, 1))
-        else:
-            w = np.array(x).reshape((1, -1, 1))
+        w = np.array(x).reshape((1, -1, 1))
         sg = pineappl.import_only_subgrid.ImportOnlySubgridV1(w, [self._q2], x, x)
         grid.set_subgrid(0, 0, 0, sg)
         grid.write(self.grid)
@@ -105,11 +102,7 @@ class Integrability(interface.External):
         q2 = self._q2 * np.ones_like(self._info.xgrid)
 
         for fl, w in self._evo2fl:
-            norm = 1.0
-            # in the polarized case we want to integrate the first moment
-            if self.polarized:
-                norm = 1 / float(self._info.xgrid[0])
-            final_result += norm * w * np.sum(pdf.xfxQ2(fl, self._info.xgrid, q2))
+            final_result += w * np.sum(pdf.xfxQ2(fl, self._info.xgrid, q2))
 
         final_cv = [final_result]
 


### PR DESCRIPTION
~55c26ea843fbbae18ce5634d8b775b47bf02ef95 is not enough to compute `f(x)` and `xf(x)`.~

~I need to adjust also here:~

https://github.com/NNPDF/pinefarm/blob/71f4b737bc8faeb0bdc650e5ae742922310d6a8f/src/pinefarm/external/integrability.py#L83-L87

This PR is to make integrability running again.