### PR TITLE
Install LHAPDF and add it to pythonpath

### DIFF
--- a/src/pinefarm/external/interface.py
+++ b/src/pinefarm/external/interface.py
@@ -10,7 +10,7 @@ import tempfile
 
 import pineappl
 
-from .. import __version__, configs, tools
+from .. import __version__, configs, install, tools
 
 
 class External(abc.ABC):
@@ -67,6 +67,8 @@ class External(abc.ABC):
     @staticmethod
     def install():
         """Install all needed programs."""
+        # Everybody needs LHAPDF unless explicitly skipped
+        _ = install.lhapdf()
 
     @abc.abstractmethod
     def run(self):

--- a/src/pinefarm/external/vrap.py
+++ b/src/pinefarm/external/vrap.py
@@ -110,9 +110,8 @@ class Vrap(interface.External):
         yaml_dict = yaml.safe_load(input_card.open("r", encoding="utf-8"))
 
         # If this is a positivity runcard, generate the fake pdf
-        if "positivity_pdf" in yaml_dict:
+        if is_pos := "positivity_pdf" in yaml_dict:
             pdfname = yaml_dict["positivity_pdf"]
-            gen_pos_pdf(pdfname)
             self.pdf = pdfname
             if vrap_order != "NLO":
                 warnings.warn("Positivity DY observables are only computed at NLO")
@@ -122,6 +121,12 @@ class Vrap(interface.External):
 
         self._partial_grids = []
         self._partial_results = []
+        self._is_pos = is_pos
+
+    def _prepare_fake_pdf(self):
+        """Prepare the fake PDF when running a positivity runcard."""
+        if self._is_pos:
+            gen_pos_pdf(self.pdf)
 
     def run(self):
         """Run vrap for the given runcards.
@@ -131,6 +136,8 @@ class Vrap(interface.External):
         The MC results for each run (writen to results.out) will be read.
 
         """
+        self._prepare_fake_pdf()
+
         for b, kin_card in enumerate(self._kin_cards):
             sp.run(
                 [configs.configs["commands"]["vrap"], self._input_card, kin_card],

--- a/src/pinefarm/install.py
+++ b/src/pinefarm/install.py
@@ -18,7 +18,7 @@ from . import configs, tools
 PINEAPPL_REPO = "https://github.com/N3PDF/pineappl.git"
 "Git repo location for pineappl."
 
-LHAPDF_VERSION = "LHAPDF-6.4.0"
+LHAPDF_VERSION = "LHAPDF-6.5.4"
 "Version of LHAPDF to be used by default (if not already available)."
 
 
@@ -298,9 +298,7 @@ def lhapdf_conf(pdf):
 def lhapdf():
     """Install `LHAPDF <https://lhapdf.hepforge.org/>`_ C++ library.
 
-    Not needed:
-        - for `mg5`, since it's vendored
-        - for `yadism`, since we depend on the PyPI version
+    This is currently needed by every tool due to postprocessing requirements.
     """
 
     def installed():
@@ -354,10 +352,14 @@ def update_environ():
 
     lib = configs.configs["paths"]["lib"]
     pyver = ".".join(sys.version.split(".")[:2])
-    prepend(
-        "PYTHONPATH",
-        lib / f"python{pyver}" / "site-packages",
-    )
+
+    # Do both lib and lib64 for python just in case
+    pythonpath = lib / f"python{pyver}" / "site-packages"
+    if not pythonpath.exists():
+        pythonpath = lib.with_name("lib64") / f"python{pyver}" / "site-packages"
+
+    prepend("PYTHONPATH", pythonpath)
+    sys.path.insert(0, pythonpath.as_posix())
     prepend("PATH", configs.configs["paths"]["bin"])
     prepend("LD_LIBRARY_PATH", lib)
     prepend("PKG_CONFIG_PATH", lib / "pkgconfig")


### PR DESCRIPTION
At the moment LHAPDF is required always by pinefarm to add the right metadata at the end of the grid, so this PR just makes it so that it is installed for every program + added to the python path.

I've also bumped up the LHAPDF version.

I'm very surprised that it took this long to add lhapdf to sys.path but I guess it's the first time someone was running it without having it installed beforehand?