### PR TITLE
Make the CKM matrix into a string for yadism

### DIFF
--- a/src/pinefarm/external/yad.py
+++ b/src/pinefarm/external/yad.py
@@ -18,9 +18,14 @@ class Yadism(interface.External):
     kind = "DIS"
 
     def __init__(self, pinecard, theorycard, *args, **kwargs):
+        # Create a copy of the theorycard since we might modify some values
+        theorycard = dict(theorycard)
+
         # Default to including scale information unless explicitly avoided
         theorycard.setdefault("FactScaleVar", True)
         theorycard.setdefault("RenScaleVar", True)
+        if isinstance(theorycard["CKM"], list):
+            theorycard["CKM"] = " ".join(str(i) for i in theorycard["CKM"])
 
         super().__init__(pinecard, theorycard, *args, **kwargs)
 


### PR DESCRIPTION
`yadism` asks for a string for the CKM Matrix, while we have many runcards where the CKM is really a list. This PR just makes the change before passing the theory card to yadism

@evagroenendijk if you try to run some of the DIS datasets they will fail depending on the runcard you use, just so that you are aware.

Below a runcard that works with this PR and doesn't without (it's a minimal change to avoid having to have several versions of the same runcards).

<details>

<summary> `theory.yaml` </summary>

```
CKM:
- 0.97428
- 0.2253
- 0.00347
- 0.2252
- 0.97345
- 0.041
- 0.00862
- 0.0403
- 0.999152
Comments: NNLO nFONLL theory. Equivalent to 700/708. 4.0 baseline.
DAMP: 0
DAMPPOWERb: null
DAMPPOWERc: null
EScaleVar: null
FNS: FONLL-FFNS
FONLLParts: full
GF: 1.1663787e-05
HQ: POLE
IC: 1
ID: 4000000000
IterEv: null
MP: 0.938
MW: 80.398
MZ: 91.1876
MaxNfAs: null
MaxNfPdf: 5
ModEv: TRN
ModSV: null
NfFF: 3
PTO: 2
PTODIS: null
PTOEKO: 2
Q0: 1.65
QED: 0
Qedref: null
Qmb: 4.92
Qmc: 1.51
Qmt: 172.5
Qref: 91.2
SIN2TW: 0.23126
SxOrd: null
SxRes: null
TMC: 1
XIF: 1.0
XIR: 1.0
alphaqed: 0.0077553
alphas: 0.118
global_nx: null
kbThr: 1.0
kcThr: 1.0
ktThr: 1.0
mb: 4.92
mc: 1.51
mt: 172.5
n3lo_ad_variation:
- 0
- 0
- 0
- 0
- 0
- 0
- 0
n3lo_cf_variation: 0
nf0: 4
nfref: 5
use_fhmruvv: false
```

</theory>