### PR TITLE
Allow Python 3.13 in unittests.yml

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     uses: NNPDF/workflows/.github/workflows/python-poetry-tests.yml@v2
     with:


### PR DESCRIPTION
supersedes https://github.com/NNPDF/pinefarm/pull/124