### PR TITLE
Ploughshare download

### DIFF
--- a/src/pinefarm/cli/run.py
+++ b/src/pinefarm/cli/run.py
@@ -190,7 +190,7 @@ def run_dataset(runner):
 
             # collect results in the output pineappl grid
             runner.generate_pineappl()
-            if not hasattr(runner, "ps_link"):
+            if runner._print_comparison:
                 table.print_table(
                     table.convolute_grid(
                         runner.grid, runner.pdf, integrated=isinstance(runner, mg5.Mg5)

--- a/src/pinefarm/cli/run.py
+++ b/src/pinefarm/cli/run.py
@@ -190,18 +190,18 @@ def run_dataset(runner):
 
             # collect results in the output pineappl grid
             runner.generate_pineappl()
+            if not hasattr(runner, "ps_link"):
+                table.print_table(
+                    table.convolute_grid(
+                        runner.grid, runner.pdf, integrated=isinstance(runner, mg5.Mg5)
+                    ),
+                    runner.results(),
+                    runner.dest,
+                )
 
-            table.print_table(
-                table.convolute_grid(
-                    runner.grid, runner.pdf, integrated=isinstance(runner, mg5.Mg5)
-                ),
-                runner.results(),
-                runner.dest,
-            )
-
-            # TODO: annotate_version should be a post-processing step
-            # however at the moment only works in 1-grid cases
-            runner.annotate_versions()
+                # TODO: annotate_version should be a post-processing step
+                # however at the moment only works in 1-grid cases
+                runner.annotate_versions()
 
         runner.postprocess()
 

--- a/src/pinefarm/external/__init__.py
+++ b/src/pinefarm/external/__init__.py
@@ -58,5 +58,10 @@ def decide_external_tool(dsname: str):
         from . import mg5  # pylint: disable=import-outside-toplevel
 
         return mg5.Mg5, "blue"
+    
+    if (configs["paths"]["runcards"] / dsname / "ploughshare_link.txt").exists():
+        from . import plough
+
+        return plough.Plough, "purple"
 
     raise ValueError(f"pinefarm could not discover the tool to use for {dsname}")

--- a/src/pinefarm/external/__init__.py
+++ b/src/pinefarm/external/__init__.py
@@ -58,7 +58,7 @@ def decide_external_tool(dsname: str):
         from . import mg5  # pylint: disable=import-outside-toplevel
 
         return mg5.Mg5, "blue"
-    
+
     if (configs["paths"]["runcards"] / dsname / "ploughshare_link.txt").exists():
         from . import plough
 

--- a/src/pinefarm/external/interface.py
+++ b/src/pinefarm/external/interface.py
@@ -42,14 +42,14 @@ class External(abc.ABC):
         runcards_path=None,
         output_folder=None,
         print_comparison=True,
-        run_without_grids=False,
+        postrun_without_grids=False,
     ):
         self.name = name
         self.theory = theory
         self.pdf = pdf
         self.timestamp = timestamp
         self._print_comparison = print_comparison
-        self._run_without_grids = run_without_grids
+        self._postrun_without_grids = postrun_without_grids
         if runcards_path is None:
             self._runcards_path = configs.configs["paths"]["runcards"]
         else:
@@ -189,7 +189,7 @@ class External(abc.ABC):
         else:
             grids = list(self.dest.glob("*.pineappl*"))
 
-        if not grids and not self._run_without_grids:
+        if not grids and not self._postrun_without_grids:
             raise ValueError("Tried to run postprocessing in a folder with no grids?")
 
         os.environ["PINECARD"] = self.source.as_posix()

--- a/src/pinefarm/external/interface.py
+++ b/src/pinefarm/external/interface.py
@@ -34,12 +34,22 @@ class External(abc.ABC):
     kind = None
 
     def __init__(
-        self, name, theory, pdf, timestamp=None, runcards_path=None, output_folder=None
+        self,
+        name,
+        theory,
+        pdf,
+        timestamp=None,
+        runcards_path=None,
+        output_folder=None,
+        print_comparison=True,
+        run_without_grids=False,
     ):
         self.name = name
         self.theory = theory
         self.pdf = pdf
         self.timestamp = timestamp
+        self._print_comparison = print_comparison
+        self._run_without_grids = run_without_grids
         if runcards_path is None:
             self._runcards_path = configs.configs["paths"]["runcards"]
         else:
@@ -179,7 +189,7 @@ class External(abc.ABC):
         else:
             grids = list(self.dest.glob("*.pineappl*"))
 
-        if not grids:
+        if not grids and not self._run_without_grids:
             raise ValueError("Tried to run postprocessing in a folder with no grids?")
 
         os.environ["PINECARD"] = self.source.as_posix()

--- a/src/pinefarm/external/interface.py
+++ b/src/pinefarm/external/interface.py
@@ -199,7 +199,7 @@ class External(abc.ABC):
         entries = {}
         if metadata.exists():
             for line in metadata.read_text().splitlines():
-                k, v = line.split("=")
+                k, v = line.split("=", 1)
                 entries[k] = v
 
         for ext in ["*.pineappl.lz4", "*.pineappl"]:

--- a/src/pinefarm/external/interface.py
+++ b/src/pinefarm/external/interface.py
@@ -212,8 +212,8 @@ class External(abc.ABC):
                 k, v = line.split("=", 1)
                 entries[k] = v
 
-        if hasattr(self, "ploughshare_id"):
-            entries["ploughshare_id"] = self.ploughshare_id
+        if hasattr(self, "ploughshare_metadata_link"):
+            entries["ploughshare_link"] = self.ploughshare_metadata_link
 
         for ext in ["*.pineappl.lz4", "*.pineappl"]:
             for grid in self.dest.glob(ext):

--- a/src/pinefarm/external/interface.py
+++ b/src/pinefarm/external/interface.py
@@ -212,6 +212,9 @@ class External(abc.ABC):
                 k, v = line.split("=", 1)
                 entries[k] = v
 
+        if hasattr(self, "ploughshare_id"):
+            entries["ploughshare_id"] = self.ploughshare_id
+
         for ext in ["*.pineappl.lz4", "*.pineappl"]:
             for grid in self.dest.glob(ext):
                 tools.update_grid_metadata(grid, self.gridtmp, entries)

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -1,16 +1,16 @@
-'''
-Download grids + convert them to pineappl format
-'''
+"""Download grids + convert them to pineappl format."""
 
-from . import interface
-from .. import table
-import requests
-import urllib.request
-import shutil
-import tarfile
-import subprocess
 import os
+import shutil
+import subprocess
+import tarfile
+import urllib.request
+
 import pineappl
+import requests
+
+from .. import table
+from . import interface
 
 PLOUGHSHARE_LINK_FILENAME = "ploughshare_link.txt"
 GRIDS_PROCESSOR = "process_grids.sh"
@@ -18,25 +18,24 @@ GRIDS_TMP = "grids"
 
 
 class Plough(interface.External):
+    """Interface provider."""
 
     def __init__(self, pinecard, theorycard, *args, **kwargs):
         super().__init__(pinecard, theorycard, *args, **kwargs)
-        self.ps_link = self.source/PLOUGHSHARE_LINK_FILENAME
+        self.ps_link = self.source / PLOUGHSHARE_LINK_FILENAME
         with open(self.ps_link) as ps_link:
             self.link = ps_link.readline()
-        
-        self.filename = self.link.rsplit('/')[-1]
-        self.dir_name = self.filename.rsplit('.', 1)[0]
-        self.tarball = self.dest/self.filename
-        self.processor = self.source/GRIDS_PROCESSOR
+
+        self.filename = self.link.rsplit("/")[-1]
+        self.dir_name = self.filename.rsplit(".", 1)[0]
+        self.tarball = self.dest / self.filename
+        self.processor = self.source / GRIDS_PROCESSOR
         self.run()
         self.generate_pineappl()
         self.timestamp = 0
-    
+
     def run(self):
-        '''
-        Download and extract the .tgz file
-        '''
+        """Download and extract the .tgz file."""
         print("Downloading from ploughshare...")
         self.download_to_dest()
         print(f"Grids successfully downloaded to {self.tarball}")
@@ -45,12 +44,15 @@ class Plough(interface.External):
         print(f"Grids successfully extracted to {self.dir_name}")
 
     def results(self):
+        """Results are collected and compared at the pineappl (script) level."""
         pass
 
     def collect_versions(self):
+        """No additional programs involved."""
         return {}
-    
+
     def generate_pineappl(self):
+        """Converts donwloaded grids into pineappl format."""
         print("Grid conversion started...")
         # the grids are converted and processed here
         os.environ["PS_DIR"] = str(self.grids_dir)
@@ -59,23 +61,21 @@ class Plough(interface.External):
         if os.access(self.processor, os.X_OK):
             shutil.copy2(self.processor, self.dest)
             subprocess.run("./process_grids.sh", cwd=self.dest, check=True)
-            (self.dest/"process_grids.sh").unlink()
+            (self.dest / "process_grids.sh").unlink()
         else:
-            raise ValueError(f"Grid conversion file present but not executable: {self.processor}")
+            raise ValueError(
+                f"Grid conversion file present but not executable: {self.processor}"
+            )
         self.grids = []
         for g in self.dest.glob("*.pineappl.lz4"):
             self.grids.append(g)
-        
+
     def download_to_dest(self):
-        '''
-        Download the file and move it to the output folder
-        '''
-        urllib.request.urlretrieve(self.link, self.dest/self.filename)
+        """Download the file and move it to the output folder."""
+        urllib.request.urlretrieve(self.link, self.dest / self.filename)
 
     def extract_tarball(self):
-        '''
-        extract the contents
-        '''
+        """Extract the contents."""
         with tarfile.open(self.tarball, "r:*") as tf:
             tf.extractall(self.dest)
-        self.grids_dir = self.dest/self.dir_name/GRIDS_TMP
+        self.grids_dir = self.dest / self.dir_name / GRIDS_TMP

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -23,8 +23,7 @@ class Plough(interface.External):
     def __init__(self, pinecard, theorycard, *args, **kwargs):
         super().__init__(pinecard, theorycard, *args, **kwargs)
         self.ps_link = self.source / PLOUGHSHARE_LINK_FILENAME
-        with open(self.ps_link) as ps_link:
-            self.link = ps_link.readline()
+        self.link = self.ps_link.read_text()
 
         self.filename = self.link.rsplit("/")[-1]
         self.dir_name = self.filename.rsplit(".", 1)[0]

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -31,7 +31,7 @@ class Plough(interface.External):
         self.link = self.ps_link.read_text()
 
         self.filename = self.link.rsplit("/")[-1]
-        self.dir_name = self.filename.rsplit(".", 1)[0]
+        self.ploughshare_id = self.filename.rsplit(".", 1)[0]
         self.tarball = self.dest / self.filename
 
     def run(self):
@@ -71,11 +71,11 @@ class Plough(interface.External):
         """Extract the contents."""
         with tarfile.open(self.tarball, "r:*") as tf:
             tf.extractall(self.dest)
-        self.grids_dir = self.dest / self.dir_name / GRIDS_FROM_PS
+        self.grids_dir = self.dest / self.ploughshare_id / GRIDS_FROM_PS
         grids_list = sorted(os.listdir(self.grids_dir))
         for grid in grids_list:
             grid_num, extension = grid.split(".", 2)[1:]
             grid_num = grid_num[-3:]
             os.rename(self.grids_dir / grid, self.dest / f"grid_{grid_num}.{extension}")
-        shutil.rmtree(self.dest / self.dir_name)
+        shutil.rmtree(self.dest / self.ploughshare_id)
         self.tarball.unlink()

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -12,7 +12,7 @@ from .. import table
 from . import interface
 
 PLOUGHSHARE_LINK_FILENAME = "ploughshare_link.txt"
-GRIDS_TMP = "grids"
+GRIDS_FROM_PS = "grids"
 
 
 class Plough(interface.External):
@@ -71,7 +71,7 @@ class Plough(interface.External):
         """Extract the contents."""
         with tarfile.open(self.tarball, "r:*") as tf:
             tf.extractall(self.dest)
-        self.grids_dir = self.dest / self.dir_name / GRIDS_TMP
+        self.grids_dir = self.dest / self.dir_name / GRIDS_FROM_PS
         grids_list = sorted(os.listdir(self.grids_dir))
         for grid in grids_list:
             grid_num, extension = grid.split(".", 2)[1:]

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -1,0 +1,80 @@
+from . import interface
+from .. import table
+import requests
+import shutil
+import tarfile
+import subprocess
+import os
+import pineappl
+
+'''
+Download grids + convert them to pineappl format
+'''
+
+class Plough(interface.External):
+
+    def __init__(self, pinecard, theorycard, *args, **kwargs):
+        super().__init__(pinecard, theorycard, *args, **kwargs)
+        self.ps_link = self.source/"ploughshare_link.txt"
+        with open(self.ps_link) as ps_link:
+            self.link = ps_link.readline()
+        
+        self.filename = self.link.rsplit('/')[-1]
+        self.foldername = self.filename.rsplit('.', 1)[0]
+        self.tarball = self.dest/self.filename
+        self.processor = self.source/"process_grids.sh"
+        self.run()
+        self.generate_pineappl()
+        self.timestamp = 0
+    
+    def run(self):
+        '''
+        Download and extract the .tgz file
+        '''
+        print("Downloading from ploughshare...")
+        self.download_to_dest()
+        print(f"Grids successfully downloaded to {self.tarball}")
+        print("Extracting files...")
+        self.extract_tarball()
+        print(f"Grids successfully extracted to {self.foldername}")
+
+    def results(self):
+        pass
+
+    def collect_versions(self):
+        return {}
+    
+    def generate_pineappl(self):
+        print("Grid conversion started...")
+        # the grids are converted and processed here
+        os.environ["PS_DIR"] = str(self.gridsfolder)
+        # note that filename is also foldername
+        os.environ["FILENAME"] = str(self.foldername)
+        if os.access(self.processor, os.X_OK):
+            shutil.copy2(self.processor, self.dest)
+            subprocess.run("./process_grids.sh", cwd=self.dest, check=True)
+            (self.dest/"process_grids.sh").unlink()
+        else:
+            raise ValueError(f"Grid conversion file present but not executable: {self.processor}")
+        self.grids = []
+        for g in self.dest.glob("*.pineappl.lz4"):
+            self.grids.append(g)
+        
+    def download_to_dest(self):
+        '''
+        Download the file and move it to the output folder
+        '''
+        with requests.get(self.link, stream=True) as r:
+            r.raise_for_status()
+            with (self.dest/self.filename).open("wb") as f:
+                for chunk in r.iter_content(chunk_size=1024*1024):
+                    if chunk:
+                        f.write(chunk)
+
+    def extract_tarball(self):
+        '''
+        extract the contents
+        '''
+        with tarfile.open(self.tarball, "r:*") as tf:
+            tf.extractall(self.dest)
+        self.gridsfolder = self.dest/self.foldername/"grids"

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -2,7 +2,6 @@
 
 import os
 import shutil
-import subprocess
 import tarfile
 import urllib.request
 
@@ -13,7 +12,6 @@ from .. import table
 from . import interface
 
 PLOUGHSHARE_LINK_FILENAME = "ploughshare_link.txt"
-GRIDS_PROCESSOR = "process_grids.sh"
 GRIDS_TMP = "grids"
 
 
@@ -28,19 +26,25 @@ class Plough(interface.External):
         self.filename = self.link.rsplit("/")[-1]
         self.dir_name = self.filename.rsplit(".", 1)[0]
         self.tarball = self.dest / self.filename
-        self.processor = self.source / GRIDS_PROCESSOR
-        self.run()
-        self.generate_pineappl()
-        self.timestamp = 0
 
     def run(self):
         """Download and extract the .tgz file."""
         print("Downloading from ploughshare...")
-        self.download_to_dest()
+        try:
+            self.download_to_dest()
+            if self.tarball.exists():
+                print(f"Grids successfully downloaded to {self.tarball}")
+            else:
+                raise FileNotFoundError(
+                    f"{self.tarball} not found but the download didn't seem to fail?"
+                )
+        except Exception as e:
+            raise FileNotFoundError(f"{self.tarball} could not be downloaded!") from e
         print(f"Grids successfully downloaded to {self.tarball}")
         print("Extracting files...")
         self.extract_tarball()
-        print(f"Grids successfully extracted to {self.dir_name}")
+        print(f"Grids successfully extracted to {self.dest}")
+        self.cleanup()
 
     def results(self):
         """Results are collected and compared at the pineappl (script) level."""
@@ -51,26 +55,11 @@ class Plough(interface.External):
         return {}
 
     def generate_pineappl(self):
-        """Converts donwloaded grids into pineappl format."""
-        print("Grid conversion started...")
-        # the grids are converted and processed here
-        os.environ["PS_DIR"] = str(self.grids_dir)
-        # note that filename is also dir_name
-        os.environ["FILENAME"] = str(self.dir_name)
-        if os.access(self.processor, os.X_OK):
-            shutil.copy2(self.processor, self.dest)
-            subprocess.run("./process_grids.sh", cwd=self.dest, check=True)
-            (self.dest / "process_grids.sh").unlink()
-        else:
-            raise ValueError(
-                f"Grid conversion file present but not executable: {self.processor}"
-            )
-        self.grids = []
-        for g in self.dest.glob("*.pineappl.lz4"):
-            self.grids.append(g)
+        """Grids are converted in postrun.sh."""
+        return
 
     def download_to_dest(self):
-        """Download the file and move it to the output folder."""
+        """Download the file to the output folder."""
         urllib.request.urlretrieve(self.link, self.dest / self.filename)
 
     def extract_tarball(self):
@@ -78,3 +67,14 @@ class Plough(interface.External):
         with tarfile.open(self.tarball, "r:*") as tf:
             tf.extractall(self.dest)
         self.grids_dir = self.dest / self.dir_name / GRIDS_TMP
+        grids_list = sorted(os.listdir(self.grids_dir))
+        for i, grid in enumerate(grids_list):
+            extension = grid.split(".", 2)[2]
+            print(extension)
+            os.rename(self.grids_dir / grid, self.dest / f"grid_{i}.{extension}")
+
+    def cleanup(self):
+        """Delete unnecessary files and create tmp.pineappl.lz4 to allow postprocessing."""
+        shutil.rmtree(self.dest / self.dir_name)
+        self.tarball.unlink()
+        open(self.dest / "tmp.pineappl.lz4", "x")

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -16,8 +16,7 @@ class Plough(interface.External):
     def __init__(self, pinecard, theorycard, *args, **kwargs):
         super().__init__(pinecard, theorycard, *args, **kwargs)
         self.ps_link = self.source/"ploughshare_link.txt"
-        with open(self.ps_link) as ps_link:
-            self.link = ps_link.readline()
+        self.link = self.ps_link.read_text()
         
         self.filename = self.link.rsplit('/')[-1]
         self.foldername = self.filename.rsplit('.', 1)[0]

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -16,38 +16,34 @@ GRIDS_TMP = "grids"
 
 
 class Plough(interface.External):
-    """Interface provider."""
+    """Interface to download grids directly from ploughshare."""
 
     def __init__(self, pinecard, theorycard, *args, **kwargs):
-        super().__init__(pinecard, theorycard, *args, **kwargs)
+        super().__init__(
+            pinecard,
+            theorycard,
+            *args,
+            print_comparison=False,
+            postrun_without_grids=True,
+            **kwargs,
+        )
         self.ps_link = self.source / PLOUGHSHARE_LINK_FILENAME
         self.link = self.ps_link.read_text()
 
         self.filename = self.link.rsplit("/")[-1]
         self.dir_name = self.filename.rsplit(".", 1)[0]
         self.tarball = self.dest / self.filename
-        self._print_comparison = False
-        self._run_without_grids = True
 
     def run(self):
         """Download and extract the .tgz file."""
         print("Downloading from ploughshare...")
-        try:
-            self.download_to_dest()
-            if self.tarball.exists():
-                print(f"Grids successfully downloaded to {self.tarball}")
-            else:
-                raise FileNotFoundError(
-                    f"{self.tarball} not found but the download didn't seem to fail?"
-                )
-        except Exception as e:
-            raise FileNotFoundError(f"{self.tarball} could not be downloaded!") from e
+        self.download_to_dest()
         print("Extracting files...")
         self.extract_tarball()
         print(f"Grids successfully extracted to {self.dest}")
 
     def results(self):
-        """Results are collected and compared at the pineappl (script) level."""
+        """Do nothing."""
         pass
 
     def collect_versions(self):
@@ -60,7 +56,16 @@ class Plough(interface.External):
 
     def download_to_dest(self):
         """Download the file to the output folder."""
-        urllib.request.urlretrieve(self.link, self.dest / self.filename)
+        try:
+            urllib.request.urlretrieve(self.link, self.dest / self.filename)
+            if self.tarball.exists():
+                print(f"Grids successfully downloaded to {self.tarball}")
+            else:
+                raise FileNotFoundError(
+                    f"{self.tarball} not found but the download didn't seem to fail?"
+                )
+        except Exception as e:
+            raise FileNotFoundError(f"{self.tarball} could not be downloaded!") from e
 
     def extract_tarball(self):
         """Extract the contents."""
@@ -68,8 +73,9 @@ class Plough(interface.External):
             tf.extractall(self.dest)
         self.grids_dir = self.dest / self.dir_name / GRIDS_TMP
         grids_list = sorted(os.listdir(self.grids_dir))
-        for i, grid in enumerate(grids_list):
-            extension = grid.split(".", 2)[2]
-            os.rename(self.grids_dir / grid, self.dest / f"grid_{i}.{extension}")
+        for grid in grids_list:
+            grid_num, extension = grid.split(".", 2)[1:]
+            grid_num = grid_num[-3:]
+            os.rename(self.grids_dir / grid, self.dest / f"grid_{grid_num}.{extension}")
         shutil.rmtree(self.dest / self.dir_name)
         self.tarball.unlink()

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -13,6 +13,10 @@ from . import interface
 
 PLOUGHSHARE_LINK_FILENAME = "ploughshare_link.txt"
 GRIDS_FROM_PS = "grids"
+PLOUGHSHARE_METADATA_LINK = (
+    "https://ploughshare.web.cern.ch/ploughshare/record.php?group="
+)
+DATASET_FOR_METADATA_LINK = "&dataset="
 
 
 class Plough(interface.External):
@@ -33,6 +37,13 @@ class Plough(interface.External):
         self.filename = self.link.rsplit("/")[-1]
         self.ploughshare_id = self.filename.rsplit(".", 1)[0]
         self.tarball = self.dest / self.filename
+        self.group = self.ploughshare_id.split("-", 1)[0]
+        self.ploughshare_metadata_link = (
+            PLOUGHSHARE_METADATA_LINK
+            + self.group
+            + DATASET_FOR_METADATA_LINK
+            + self.ploughshare_id
+        )
 
     def run(self):
         """Download and extract the .tgz file."""

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -26,6 +26,8 @@ class Plough(interface.External):
         self.filename = self.link.rsplit("/")[-1]
         self.dir_name = self.filename.rsplit(".", 1)[0]
         self.tarball = self.dest / self.filename
+        self._print_comparison = False
+        self._run_without_grids = True
 
     def run(self):
         """Download and extract the .tgz file."""
@@ -40,11 +42,9 @@ class Plough(interface.External):
                 )
         except Exception as e:
             raise FileNotFoundError(f"{self.tarball} could not be downloaded!") from e
-        print(f"Grids successfully downloaded to {self.tarball}")
         print("Extracting files...")
         self.extract_tarball()
         print(f"Grids successfully extracted to {self.dest}")
-        self.cleanup()
 
     def results(self):
         """Results are collected and compared at the pineappl (script) level."""
@@ -70,11 +70,6 @@ class Plough(interface.External):
         grids_list = sorted(os.listdir(self.grids_dir))
         for i, grid in enumerate(grids_list):
             extension = grid.split(".", 2)[2]
-            print(extension)
             os.rename(self.grids_dir / grid, self.dest / f"grid_{i}.{extension}")
-
-    def cleanup(self):
-        """Delete unnecessary files and create tmp.pineappl.lz4 to allow postprocessing."""
         shutil.rmtree(self.dest / self.dir_name)
         self.tarball.unlink()
-        open(self.dest / "tmp.pineappl.lz4", "x")

--- a/src/pinefarm/external/plough.py
+++ b/src/pinefarm/external/plough.py
@@ -1,27 +1,34 @@
+'''
+Download grids + convert them to pineappl format
+'''
+
 from . import interface
 from .. import table
 import requests
+import urllib.request
 import shutil
 import tarfile
 import subprocess
 import os
 import pineappl
 
-'''
-Download grids + convert them to pineappl format
-'''
+PLOUGHSHARE_LINK_FILENAME = "ploughshare_link.txt"
+GRIDS_PROCESSOR = "process_grids.sh"
+GRIDS_TMP = "grids"
+
 
 class Plough(interface.External):
 
     def __init__(self, pinecard, theorycard, *args, **kwargs):
         super().__init__(pinecard, theorycard, *args, **kwargs)
-        self.ps_link = self.source/"ploughshare_link.txt"
-        self.link = self.ps_link.read_text()
+        self.ps_link = self.source/PLOUGHSHARE_LINK_FILENAME
+        with open(self.ps_link) as ps_link:
+            self.link = ps_link.readline()
         
         self.filename = self.link.rsplit('/')[-1]
-        self.foldername = self.filename.rsplit('.', 1)[0]
+        self.dir_name = self.filename.rsplit('.', 1)[0]
         self.tarball = self.dest/self.filename
-        self.processor = self.source/"process_grids.sh"
+        self.processor = self.source/GRIDS_PROCESSOR
         self.run()
         self.generate_pineappl()
         self.timestamp = 0
@@ -35,7 +42,7 @@ class Plough(interface.External):
         print(f"Grids successfully downloaded to {self.tarball}")
         print("Extracting files...")
         self.extract_tarball()
-        print(f"Grids successfully extracted to {self.foldername}")
+        print(f"Grids successfully extracted to {self.dir_name}")
 
     def results(self):
         pass
@@ -46,9 +53,9 @@ class Plough(interface.External):
     def generate_pineappl(self):
         print("Grid conversion started...")
         # the grids are converted and processed here
-        os.environ["PS_DIR"] = str(self.gridsfolder)
-        # note that filename is also foldername
-        os.environ["FILENAME"] = str(self.foldername)
+        os.environ["PS_DIR"] = str(self.grids_dir)
+        # note that filename is also dir_name
+        os.environ["FILENAME"] = str(self.dir_name)
         if os.access(self.processor, os.X_OK):
             shutil.copy2(self.processor, self.dest)
             subprocess.run("./process_grids.sh", cwd=self.dest, check=True)
@@ -63,12 +70,7 @@ class Plough(interface.External):
         '''
         Download the file and move it to the output folder
         '''
-        with requests.get(self.link, stream=True) as r:
-            r.raise_for_status()
-            with (self.dest/self.filename).open("wb") as f:
-                for chunk in r.iter_content(chunk_size=1024*1024):
-                    if chunk:
-                        f.write(chunk)
+        urllib.request.urlretrieve(self.link, self.dest/self.filename)
 
     def extract_tarball(self):
         '''
@@ -76,4 +78,4 @@ class Plough(interface.External):
         '''
         with tarfile.open(self.tarball, "r:*") as tf:
             tf.extractall(self.dest)
-        self.gridsfolder = self.dest/self.foldername/"grids"
+        self.grids_dir = self.dest/self.dir_name/GRIDS_TMP


### PR DESCRIPTION
Addresses #102 and NNPDF/pinecards#192.

This is the initial implementation of the class `Plough` that downloads the grids from ploughshare and converts them into pineappl format (or does whatever is necessary: cutting bins, renaming grids etc.)

# Pinecard structure:
The folder would contain two files: `ploughshare_link.txt` and `process_grids.sh` (optionally `postrun.sh` and `metadata.txt`). Please have a look at the [CMS_2JET_8TEV_3D](https://github.com/NNPDF/pinecards/tree/7ed82106c97a5ed909ad6076c6b006024b94fe80/CMS_2JET_8TEV_3D) example.
`ploughshare_link.txt`: contains the link to the file that has to be downloaded
`process_grids.sh`: responsible for conversion etc.

# Class structure
`Plough.run()`: downloads the (tarball) file and extracts it in the output folder
`Plough.generate_pineappl()`: runs the `process_grids.sh` script inside the output folder (also tells it the grid names)

These methods are run when the class is initialised. If they were run conventionally (i.e. by [`run.py`](https://github.com/NNPDF/pinefarm/blob/0490d3c18fb4704cbdde31c65d0f4e0107c87610/src/pinefarm/cli/run.py#L173)), then an external-pineappl comparison would have to be made at the pinefarm level - this is already done by `pineappl import`. Also, lines 194-200 of `run.py` assume that only one grid was generated.

The conversion happens inside `process_grids.sh` instead of `postrun.sh`, as `postrun.sh` only assumes that one grid was generated.